### PR TITLE
If using excanvas, disable animations by default and use rgb colors

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -26,6 +26,12 @@
     '#4D5360'  // dark grey
   ];
 
+  var usingExcanvas = typeof window.G_vmlCanvasManager === 'object' &&
+    window.G_vmlCanvasManager !== null &&
+    typeof window.G_vmlCanvasManager.initElement === 'function';
+
+  if (usingExcanvas) Chart.defaults.global.animation = false;
+
   angular.module('chart.js', [])
     .provider('ChartJs', ChartJsProvider)
     .factory('ChartJsFactory', ['ChartJs', ChartJsFactory])
@@ -97,11 +103,7 @@
           elem.replaceWith(container);
           container.appendChild(elem[0]);
 
-          if (typeof window.G_vmlCanvasManager === 'object' && window.G_vmlCanvasManager !== null) {
-            if (typeof window.G_vmlCanvasManager.initElement === 'function') {
-              window.G_vmlCanvasManager.initElement(elem[0]);
-            }
-          }
+          if (usingExcanvas) window.G_vmlCanvasManager.initElement(elem[0]);
 
           // Order of setting "watch" matter
 
@@ -231,7 +233,12 @@
     }
 
     function rgba (colour, alpha) {
-      return 'rgba(' + colour.concat(alpha).join(',') + ')';
+      if (usingExcanvas) {
+        // rgba not supported by IE8
+        return 'rgb(' + colour.join(',') + ')';
+      } else {
+        return 'rgba(' + colour.concat(alpha).join(',') + ')';
+      }
     }
 
     // Credit: http://stackoverflow.com/a/11508164/1190235


### PR DESCRIPTION
This is based on the comment added by @romain-ni for this issue: https://github.com/jtblin/angular-chart.js/issues/89

I believe disabling animations by default makes sense when making use of IE's VML, especially since nothing prevents the developer from explicitly turning them back on.

Also, we could update the Myplanet fork of angular-chart once this goes in: https://github.com/jtblin/angular-chart.js/pull/154
