### PR TITLE
Do not create a legend when using excanvas

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -275,6 +275,8 @@
     }
 
     function setLegend (elem, chart) {
+      if (usingExcanvas) return;  // the code below has a bug in IE8
+
       var $parent = elem.parent(),
           $oldLegend = $parent.find('chart-legend'),
           legend = '<chart-legend>' + chart.generateLegend() + '</chart-legend>';


### PR DESCRIPTION
There's a bug with ie8 where it repeats the legend multiple times, I think this is pointing to a bug in setLegend() that only occurs in IE8.
